### PR TITLE
Shutdown VMs on host shutdown

### DIFF
--- a/machines/mithlond/default.nix
+++ b/machines/mithlond/default.nix
@@ -98,6 +98,7 @@
   };
   virtualisation.libvirtd = {
     allowedBridges = [ "br0" ];
+    onShutdown = "shutdown";
   };
   programs.virt-manager.enable = true;
   users.users.sjanssen.extraGroups = [ "docker" ];


### PR DESCRIPTION
Resolves issue where USB devices are missing on VM restore.