### PR TITLE
Remove material-shell from packages

### DIFF
--- a/nixos/home-manager/ungoliant.nix
+++ b/nixos/home-manager/ungoliant.nix
@@ -80,7 +80,6 @@
     entr
     zoom-us
     cascadia-code
-    gnomeExtensions.material-shell
     jq
 
     (pkgs.haskellPackages.ghcWithPackages (self: [


### PR DESCRIPTION
Remove `gnomeExtensions.material-shell` from the `home.packages` list in `nixos/home-manager/ungoliant.nix`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/spencerjanssen/dotfiles/pull/275?shareId=c141424f-4ad5-4270-8d34-6167d2440c40).