### PR TITLE
Automatically rebase flake update PRs when main is updated

### DIFF
--- a/.github/workflows/rebase-flake-update-prs.yml
+++ b/.github/workflows/rebase-flake-update-prs.yml
@@ -1,0 +1,37 @@
+name: Rebase Flake Update PRs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  rebase_flake_update_prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          ssh-key: ${{ secrets.FLAKE_UPDATE_SSH_KEY }}
+
+      - name: Set up Git
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Find open PRs with flake-update branch
+        id: find_prs
+        run: |
+          prs=$(gh pr list --state open --base main --json number,headRefName --jq '.[] | select(.headRefName == "flake-update") | .number')
+          echo "::set-output name=prs::$prs"
+
+      - name: Rebase flake-update branch onto main
+        if: steps.find_prs.outputs.prs != ''
+        run: |
+          for pr in $(echo ${{ steps.find_prs.outputs.prs }}); do
+            git fetch origin pull/$pr/head:pr-$pr
+            git checkout pr-$pr
+            git rebase origin/main
+            git push --force-with-lease origin pr-$pr:flake-update
+          done


### PR DESCRIPTION
Add a new GitHub Actions workflow to automatically rebase flake update PRs when the main branch is updated.

* **Workflow Trigger**: Trigger on `push` events to the `main` branch and `workflow_dispatch` events.
* **Repository Checkout**: Check out the repository using `actions/checkout@v2` with `ssh-key: ${{ secrets.FLAKE_UPDATE_SSH_KEY }}`.
* **Git Configuration**: Set up Git with user name and email for GitHub Actions.
* **Find Open PRs**: Find open PRs with the `flake-update` branch using GitHub CLI.
* **Rebase and Push**: Rebase the `flake-update` branch onto the updated `main` branch and push the rebased branches back to the repository.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/spencerjanssen/dotfiles/pull/276?shareId=ce60e281-8a82-453d-bf07-6b28bd1afbcf).