### PR TITLE
Fix flake update rebase action

### DIFF
--- a/.github/workflows/rebase-flake-update-prs.yml
+++ b/.github/workflows/rebase-flake-update-prs.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   rebase_flake_update_prs:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Add `GH_TOKEN` environment variable to GitHub Actions workflow.

* Add `env` section to the `rebase_flake_update_prs` job.
* Set `GH_TOKEN` environment variable using `${{ secrets.GITHUB_TOKEN }}`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/spencerjanssen/dotfiles/pull/279?shareId=b7148424-95f0-4c03-8e4d-de9a095306b8).