### PR TITLE
Revert "Disable node20 in the github-runner"

### DIFF
--- a/nixos/services/github-runner.nix
+++ b/nixos/services/github-runner.nix
@@ -7,8 +7,6 @@
     extraLabels = [ "dotfiles-builder" ];
     replace = true;
     tokenFile = config.age.secrets.dotfiles-builder-github-token.path;
-    # remove when https://github.com/NixOS/nixpkgs/pull/524856 lands in nixos-unstable:
-    nodeRuntimes = [ "node24" ];
   };
   age.secrets = {
     dotfiles-builder-github-token.file = ../../secrets/dotfiles-builder-github-token.age;


### PR DESCRIPTION
This reverts commit e2801225ea5a0768d4de28a0efbd6d583ee68099.

This workaround is no longer necessary since node20 is disabled in nixpkgs.