### PR TITLE
Drop gh-actions-cache extension

### DIFF
--- a/home-manager/homes/work.nix
+++ b/home-manager/homes/work.nix
@@ -42,7 +42,6 @@
     gh = {
       enable = true;
       gitCredentialHelper.enable = true;
-      extensions = [ pkgs.gh-actions-cache ];
     };
     git = {
       enable = true;


### PR DESCRIPTION
Has been rolled into main gh by default.